### PR TITLE
Updated Cannabis info tooltip

### DIFF
--- a/extension/scripts/global/functions/torn.js
+++ b/extension/scripts/global/functions/torn.js
@@ -125,7 +125,7 @@ const CASINO_GAMES = ["slots", "roulette", "high-low", "keno", "craps", "bookie"
 const DRUG_INFORMATION = {
 	// Cannabis
 	196: {
-		pros: ["Increased crime success rate", "+2-3 Nerve"],
+		pros: ["+8-12 Nerve"],
 		cons: ["-20% Strength", "-25% Defense", "-35% Speed"],
 		cooldown: "60-90 minutes",
 		overdose: {


### PR DESCRIPTION
- Updated nerve gains to current values.
- Removed "crime success gain" line, as there is no evidence it does that and no mention anywhere of it. Rejected by multiple people, even Wiki contributors: [https://www.torn.com/forums.php#/p=threads&t=16338009&to=23595012](https://www.torn.com/forums.php#/p=threads&t=16338009&to=23595012)